### PR TITLE
forgot password backend functionality #12

### DIFF
--- a/middleware/fetchuser.js
+++ b/middleware/fetchuser.js
@@ -1,6 +1,5 @@
 import jwt from 'jsonwebtoken';
-const JWT_SECRET = process.env.JWT_SECRET || 'Skanarul$123@';
-
+const JWT_SECRET = process.env.JWT_SECRET;
 const fetchuser = (req, res, next) => {
     // Get the user from the jwt token and add id to req object
     const authHeader = req.header('Authorization');

--- a/middleware/fetchuser.js
+++ b/middleware/fetchuser.js
@@ -1,17 +1,22 @@
 import jwt from 'jsonwebtoken';
-const JWT_SECRET = process.env.JWT_SECRET;
+const JWT_SECRET = process.env.JWT_SECRET || 'Skanarul$123@';
 
 const fetchuser = (req, res, next) => {
     // Get the user from the jwt token and add id to req object
-    const token = req.header('auth-token');
+    const authHeader = req.header('Authorization');
+    const token = authHeader && authHeader.startsWith('Bearer ') ? authHeader.split(' ')[1] : null;
+    console.log("Received jet secret Token:", JWT_SECRET);
     if(!token) {
         res.status(401).send({error: "Please authenticate using a valid token"});
     }
     try {
+        console.log("before Decoded Data:");
         const data = jwt.verify(token, JWT_SECRET);
+        console.log("Decoded Data:", data);
         req.user = data.user;
         next();
     } catch(error) {
+        console.error("Token verification failed:", error.name, error.message);
         res.status(401).send({error: "Please authenticate using a valid token"});
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "express-validation": "^4.1.1",
     "express-validator": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.5.1"
+    "mongoose": "^8.5.1",
+    "nodemailer": "^6.9.15"
   },
   "devDependencies": {
     "nodemon": "^3.1.4"

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,9 +5,17 @@ import { body, validationResult } from 'express-validator';
 
 import User from '../models/User.js';
 import fetchuser from '../middleware/fetchuser.js';
+import nodemailer from 'nodemailer';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'ChanakyaNiti';
+
+
+const JWT_SECRET = process.env.JWT_SECRET || 'Skanarul$123@';
+const JWT_EXPIRY = process.env.JWT_EXPIRY || '1h';
 const router = express.Router();
+console.log("JWT_SECRET:", JWT_SECRET); 
+
+
+
 
 // Route 1: Create a User using: POST "/api/auth/signup". No Login Required
 router.post('/signup', [
@@ -46,9 +54,13 @@ router.post('/signup', [
         id: user.id
       }
     }
-
+   // Verify JWT_SECRET is correctly set
+    console.log("JWT_SECRET:", JWT_SECRET);
+    if (!JWT_SECRET) {
+      throw new Error("JWT_SECRET is not defined");
+    }
     // jwt will signature a token and give it to the user after login or say after verification/authentication
-    const authToken = jwt.sign(data, JWT_SECRET);
+    const authToken = jwt.sign(data, JWT_SECRET,{ expiresIn: JWT_EXPIRY });
     success = true;
     res.json({ success, authToken });
   } catch (error) {
@@ -86,7 +98,7 @@ router.post('/login', [
         id: user.id
       }
     }
-    const authtoken = jwt.sign(data, JWT_SECRET);
+    const authtoken = jwt.sign(data, JWT_SECRET,{ expiresIn: JWT_EXPIRY });
     success = true;
     res.json({ success, authtoken });
   } catch (error) {
@@ -100,11 +112,82 @@ router.post('/getuser', fetchuser, async (req, res) => {
   try {
     const userId = req.user.id;
     const user = await User.findById(userId).select("-password");
-    res.send(user);
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    res.status(200).json(user);
   } catch (error) {
-    console.error(error.message);
-    res.status(500).send("Internal server error.");
+    console.error("Error fetching user details:",error.message);
+    res.status(500).json({ error: "Internal server error" });
   }
 });
 
+//4 Route to send password reset link. use POST "/auth/restPasswordLink"
+router.post('/resetPasswordLink', [
+  body('email', 'Enter a valid email').isEmail(),
+], async (req, res) => {
+  try {
+    const user = await User.findOne({ email: req.body.email });
+    if (!user) {
+      return res.status(400).json({ message: "User with this email does not exist" });
+    }
+
+    const secret = JWT_SECRET + user.password;
+    const token = await jwt.sign({ email: user.email, id: user._id }, secret, { expiresIn: JWT_EXPIRY });
+
+    const url = `${process.env.FRONTEND_URL}/auth/resetpassword/${user._id}/${token}`;
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.gmail.com',
+      port: 587,
+      auth: {
+        user: process.env.EMAIL,
+        pass: process.env.PASSWORD
+      }
+    });
+
+    await transporter.sendMail({
+      to: user.email,
+      subject: 'Password Reset Link',
+      text: `Click on the link below to reset your password:\n${url}`,
+      html: `<h2>Click on the link below to reset your password</h2><a href="${url}">Password Reset</a>`
+    });
+
+    res.status(200).json({ message: "Password reset link has been sent to your email" });
+  } catch (error) {
+    res.status(500).json({ message: "Something went wrong" });
+  }
+});
+
+//5 Route to reset password. use POST "/api/auth/resetpassword/:id/:token"
+router.post('/resetpassword/:id/:token', [
+  body('password', 'Password must be at least 8 characters').isLength({ min: 8 }),
+], async (req, res) => {
+  const { id, token } = req.params;
+  const { password } = req.body;
+
+  try {
+    const user = await User.findById(id);
+    if (!user) {
+      return res.status(400).json({ message: "User does not exist" });
+    }
+
+    const secret = JWT_SECRET + user.password;
+    const decoded = jwt.verify(token, secret);
+
+    if (decoded.id === user._id.toString()) {
+      const salt = await bcrypt.genSalt(10);
+      user.password = await bcrypt.hash(password, salt);
+      await user.save();
+      res.status(200).json({ message: "Password reset successful" });
+    } else {
+      res.status(400).json({ message: "Invalid token" });
+    }
+  } catch (error) {
+    res.status(500).json({ message: "Something went wrong" });
+  }
+});
+
+
 export default router;
+
+


### PR DESCRIPTION
please accept the pr for issue #12, previous pr #19. 

**Title:** Implement Password Reset Functionality with Environment Configuration

**Description:**
    Fix #12 
- Added **password reset** functionality:
  - Users can request a reset link via `/resetPasswordLink`, and an email is sent using `nodemailer`.
  - Users reset their password via `/resetpassword/:id/:token`, verified using `jsonwebtoken`.
  - Integrated **`bcrypt`** for secure password hashing.
  - Handles expired tokens and invalid requests.

- Updated **.env** configuration for easy environment management:
  ```
  PORT=8081
  MONGODB_URI=mongodb://127.0.0.1:27017/your mongodb
  FRONTEND_URL=http://localhost:3000
  JWT_EXPIRY=1h
  JWT_SECRET=Skanarul$123@
  PASSWORD=mail permission password
  EMAIL=your email
  BACKEND_URL=http://localhost:8081/
  ```

- Enhanced **login/signup**:
  - Consistent JWT usage with expiration.
  - Secure password storage using `bcrypt`.

**Summary**: This update provides a robust password reset mechanism, improved security practices, and streamlined environment configuration for easier deployment.

See below video:
https://drive.google.com/file/d/1ZGETgRYIpFFSRAQ5gCf7U72PcEgfsm93/view?usp=drive_link

@Avdhesh-Varshney please merge the pr and fix the issue #12 